### PR TITLE
enable overallocation based on jobsize

### DIFF
--- a/src/hpc/autoscale/allocate.conf
+++ b/src/hpc/autoscale/allocate.conf
@@ -1,0 +1,3 @@
+[overallocate]
+jobsize=2
+extranode=2

--- a/src/hpc/autoscale/job/job.py
+++ b/src/hpc/autoscale/job/job.py
@@ -1,4 +1,8 @@
 import typing
+import os
+import configparser
+from hpc.autoscale import hpclogging as logging
+
 from typing import Any, Dict, Iterable, List, NewType, Optional, Union
 
 from hpc.autoscale import hpctypes as ht
@@ -34,6 +38,22 @@ def _check_type(**kwargs: Any) -> None:
         name, expected_type, type(value), value
     )
 
+
+def _initialize_job_config() -> None:
+    config_path = os.getenv("AUTOSCALE_JOB_CONFIG", "/opt/cycle/pbspro/allocate.conf")
+    cwd = os.getcwd()
+    logging.info("config_path %s", config_path)
+    logging.info("Current working directory: {0}".format(cwd))
+    if os.path.exists(config_path):
+        job_config = configparser.ConfigParser()
+        job_config.read(config_path)
+        jobsize = int(job_config['overallocate']['jobsize'])
+        extranode = int(job_config['overallocate']['extranode'])
+        return jobsize,extranode
+    else:
+        jobsize = 0
+        extranode = 0
+        return jobsize,extranode
 
 @hpcwrapclass
 class Job:
@@ -71,9 +91,18 @@ class Job:
         self.__iterations = iterations
         self.__iterations_remaining = iterations
 
+
         _check_type(node_count=node_count, type=int)
-        self.__node_count = node_count
-        self.__nodes_remaining = node_count
+        jobsize, extranode = _initialize_job_config()
+        logging.info("config %s", jobsize)
+        if node_count >= jobsize:
+            self.__node_count = node_count + extranode
+            self.__nodes_remaining = node_count + extranode
+        else:
+            self.__node_count = node_count
+            self.__nodes_remaining = node_count
+        #self.__node_count = node_count
+        #self.__nodes_remaining = node_count
 
         _check_type(colocated=colocated, type=bool)
         self.__colocated = colocated


### PR DESCRIPTION
This configurable overallocate configuration allows for better autoscaling behavior for larger jobs, where all healthy nodes are required as soon as possible to allow job start.