### PR TITLE
Feature/0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ region but we ensure that only one of them is valid at a time.
          {"node.location": "eastus"}]
 }
 ```
+
+# Timeouts
+By default we set idle and boot timeouts across all nodes.
+```"idle_timeout": 300,
+   "boot_timeout": 3600
+```
+You can also set these per nodearray.
+```"idle_timeout": {"default": 300, "nodearray1": 600, "nodearray2": 900},
+   "boot_timeout": {"default": 3600, "nodearray1": 7200, "nodearray2": 900},
+```
     
 
 # Contributing

--- a/example-celery/project.ini
+++ b/example-celery/project.ini
@@ -1,7 +1,7 @@
 [project]
-version = 0.2.7
+version = 0.2.8
 type = application
 name = celery-autoscale-demo
 
 [blobs]
-Files = cyclecloud-scalelib-0.2.7.tar.gz 
+Files = cyclecloud-scalelib-0.2.8.tar.gz 

--- a/example-celery/project.ini
+++ b/example-celery/project.ini
@@ -1,7 +1,7 @@
 [project]
-version = 0.2.8
+version = 0.2.9
 type = application
 name = celery-autoscale-demo
 
 [blobs]
-Files = cyclecloud-scalelib-0.2.8.tar.gz 
+Files = cyclecloud-scalelib-0.2.9.tar.gz 

--- a/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
+++ b/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
@@ -12,8 +12,8 @@ CC_VERSION=$(jetpack config cyclecloud.cookbooks.version)
 wget --no-check-certificate ${cs_hostname}/static/tools/cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 pip install cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 
-jetpack download --project celery-autoscale-demo cyclecloud-scalelib-0.2.8.tar.gz $CYCLECLOUD_SPEC_PATH/files/
-pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-0.2.8.tar.gz
+jetpack download --project celery-autoscale-demo cyclecloud-scalelib-0.2.9.tar.gz $CYCLECLOUD_SPEC_PATH/files/
+pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-0.2.9.tar.gz
 
 LOGGING_CONF=$(python -c 'import hpc.autoscale, os; print(os.path.abspath(os.path.join(hpc.autoscale.__file__, "..", "logging.conf")))')
 cp $LOGGING_CONF $INSTALLDIR

--- a/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
+++ b/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
@@ -12,8 +12,8 @@ CC_VERSION=$(jetpack config cyclecloud.cookbooks.version)
 wget --no-check-certificate ${cs_hostname}/static/tools/cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 pip install cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 
-jetpack download --project celery-autoscale-demo cyclecloud-scalelib-0.2.67tar.gz $CYCLECLOUD_SPEC_PATH/files/
-pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-0.2.7.tar.gz
+jetpack download --project celery-autoscale-demo cyclecloud-scalelib-0.2.8.tar.gz $CYCLECLOUD_SPEC_PATH/files/
+pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-0.2.8.tar.gz
 
 LOGGING_CONF=$(python -c 'import hpc.autoscale, os; print(os.path.abspath(os.path.join(hpc.autoscale.__file__, "..", "logging.conf")))')
 cp $LOGGING_CONF $INSTALLDIR

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-CYCLECLOUD_SCALELIB_VERSION = "0.2.7"
+CYCLECLOUD_SCALELIB_VERSION = "0.2.8"
 CYCLECLOUD_API_VERSION = "8.1.0"
 
 

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-CYCLECLOUD_SCALELIB_VERSION = "0.2.8"
+CYCLECLOUD_SCALELIB_VERSION = "0.2.9"
 CYCLECLOUD_API_VERSION = "8.1.0"
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.test import test as TestCommand  # noqa: N812
 
 import inspect
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
 
 class PyTest(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.test import test as TestCommand  # noqa: N812
 
 import inspect
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 
 class PyTest(TestCommand):

--- a/src/hpc/autoscale/cli.py
+++ b/src/hpc/autoscale/cli.py
@@ -70,9 +70,15 @@ class ScaleLibCLI(CommonCLI):
 
     @disablecommand
     def join_nodes(
-        self, config: Dict, hostnames: List[str], node_names: List[str]
+        self,
+        config: Dict,
+        hostnames: List[str],
+        node_names: List[str],
+        include_permanent: bool = False,
     ) -> None:
-        return super().join_nodes(config, hostnames, node_names)
+        return super().join_nodes(
+            config, hostnames, node_names, include_permanent=include_permanent
+        )
 
     @disablecommand
     def remove_nodes(

--- a/src/hpc/autoscale/clilib.py
+++ b/src/hpc/autoscale/clilib.py
@@ -333,9 +333,12 @@ class CommonCLI(ABC):
         return self._driver(config).new_node_history(config)
 
     def _demand_calc(
-        self, config: Dict, driver: SchedulerDriver
+        self,
+        config: Dict,
+        driver: SchedulerDriver,
+        node_mgr: Optional[NodeManager] = None,
     ) -> Tuple[DemandCalculator, List[Job]]:
-        node_mgr = self._node_mgr(config, driver)
+        node_mgr = node_mgr or self._node_mgr(config, driver)
         node_history = self._node_history(config)
         driver = self._driver(config)
 
@@ -357,13 +360,14 @@ class CommonCLI(ABC):
         config: Dict,
         driver: Optional[SchedulerDriver] = None,
         ctx_handler: Optional[DefaultContextHandler] = None,
+        node_mgr: Optional[NodeManager] = None,
     ) -> DemandCalculator:
         driver = driver or self._driver(config)
         if not ctx_handler:
             ctx_handler = self._ctx_handler(config)
             register_result_handler(ctx_handler)
 
-        dcalc, jobs = self._demand_calc(config, driver)
+        dcalc, jobs = self._demand_calc(config, driver, node_mgr)
         logging.info(
             "Calculating demand for %s jobs: %s", len(jobs), [j.name for j in jobs]
         )
@@ -432,7 +436,11 @@ class CommonCLI(ABC):
 
         nodes_to_delete = driver.handle_failed_nodes(invalid_nodes)
 
-        demand_calculator = self._demand(config, driver, ctx_handler)
+        node_mgr = self._node_mgr(config, driver)
+
+        driver.validate_nodes(scheduler_nodes, node_mgr.get_nodes())
+
+        demand_calculator = self._demand(config, driver, ctx_handler, node_mgr)
 
         failed_nodes = demand_calculator.node_mgr.get_failed_nodes()
         failed_nodes_to_delete = driver.handle_failed_nodes(failed_nodes)
@@ -475,16 +483,14 @@ class CommonCLI(ABC):
 
         def idle_at_least(node: Node) -> float:
             return parse_idle_timeout(config, node)
-        
+
         def booting_at_least(node: Node) -> float:
             return parse_boot_timeout(config, node)
 
         unmatched_for_5_mins = demand_calculator.find_unmatched_for(
             at_least=idle_at_least
         )
-        timed_out_booting = demand_calculator.find_booting(
-            at_least=booting_at_least
-        )
+        timed_out_booting = demand_calculator.find_booting(at_least=booting_at_least)
 
         # I don't care about nodes that have keep_alive=true
         timed_out_booting = [n for n in timed_out_booting if not n.keep_alive]
@@ -494,22 +500,20 @@ class CommonCLI(ABC):
 
         if timed_out_booting:
             logging.info(
-                "The following nodes have timed out while booting: %s",
-                timed_out_booting,
+                "BootTimeout reached: %s", timed_out_booting,
             )
             timed_out_to_deleted = driver.handle_boot_timeout(timed_out_booting) or []
 
         if unmatched_for_5_mins:
             node_expr = ", ".join([str(x) for x in unmatched_for_5_mins])
-            logging.info(
-                "IdleTimeout reached: %s", node_expr
-            )
+            logging.info("IdleTimeout reached: %s", node_expr)
             unmatched_nodes_to_delete = (
                 driver.handle_draining(unmatched_for_5_mins) or []
             )
-
-        nodes_to_delete = []
-        for node in timed_out_to_deleted + unmatched_nodes_to_delete:
+        nodes_to_delete.extend(timed_out_to_deleted + unmatched_nodes_to_delete)
+        can_not_delete_bc_assigned = [n for n in nodes_to_delete if n.assignments]
+        nodes_to_delete = [n for n in nodes_to_delete if not n.assignments]
+        for node in can_not_delete_bc_assigned:
             if node.assignments:
                 logging.warning(
                     "%s has jobs assigned to it so we will take no action.", node
@@ -835,14 +839,21 @@ class CommonCLI(ABC):
 
     def join_nodes_parser(self, parser: ArgumentParser) -> None:
         parser.set_defaults(read_only=False)
+        parser.add_argument("--include-permanent", action="store_true", default=False)
         self._add_hostnames(parser)
         self._add_nodenames(parser)
 
     def join_nodes(
-        self, config: Dict, hostnames: List[str], node_names: List[str]
+        self,
+        config: Dict,
+        hostnames: List[str],
+        node_names: List[str],
+        include_permanent: bool = False,
     ) -> None:
         """Adds selected nodes to the scheduler"""
         driver, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
+        if include_permanent:
+            self._node_history(config).unmark_ignored(nodes)
         joined_nodes = driver.add_nodes_to_cluster(nodes)
         print("Joined the following nodes:")
         for n in joined_nodes or []:
@@ -860,6 +871,7 @@ class CommonCLI(ABC):
         self._add_hostnames(parser)
         self._add_nodenames(parser)
         parser.add_argument("--force", action="store_true", default=False)
+        parser.add_argument("--permanent", action="store_true", default=False)
         parser.set_defaults(read_only=False)
 
     def remove_nodes(
@@ -868,9 +880,17 @@ class CommonCLI(ABC):
         hostnames: List[str],
         node_names: List[str],
         force: bool = False,
+        permanent: bool = False,
     ) -> None:
         """Removes the node from the scheduler without terminating the actual instance."""
-        self.delete_nodes(config, hostnames, node_names, force, do_delete=False)
+        self.delete_nodes(
+            config,
+            hostnames,
+            node_names,
+            do_delete=False,
+            force=force,
+            permanent=permanent,
+        )
 
     def delete_nodes_parser(self, parser: ArgumentParser) -> None:
         self._add_hostnames(parser)
@@ -883,10 +903,10 @@ class CommonCLI(ABC):
         config: Dict,
         hostnames: List[str],
         node_names: List[str],
-        force: bool = False,
         do_delete: bool = True,
+        force: bool = False,
+        permanent: bool = False,
     ) -> None:
-        """Deletes node, including draining post delete handling"""
         driver, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
 
         if not force:
@@ -926,6 +946,13 @@ class CommonCLI(ABC):
         print("Removed the following nodes from {}:".format(driver.name))
         for n in removed_nodes:
             print("   ", n)
+
+        # This should only happen when do_delete=false, but as an extra asssertion
+        if permanent and not do_delete:
+            print(
+                "Ignoring the removed nodes until join_nodes --include-permanent is called."
+            )
+            self._node_history(self.config).mark_ignored(removed_nodes)
 
     def default_output_columns_parser(self, parser: ArgumentParser) -> None:
         cmds = [

--- a/src/hpc/autoscale/hpctypes.py
+++ b/src/hpc/autoscale/hpctypes.py
@@ -221,8 +221,8 @@ class Memory(Size):
         return "memory::" + str(self)
 
     @classmethod
-    def value_of(cls, value: typing.Union[SizeValue, "Size", str]) -> "Size":
-        return Size._value_of(Memory, value)
+    def value_of(cls, value: typing.Union[SizeValue, "Size", str]) -> "Memory":
+        return Size._value_of(Memory, value)  # type: ignore
 
     def convert_to(self, new_mag: SizeMagnitude) -> "Size":
         if new_mag == self.magnitude:

--- a/src/hpc/autoscale/job/driver.py
+++ b/src/hpc/autoscale/job/driver.py
@@ -127,9 +127,6 @@ class SchedulerDriver(ABC):
         read_only = config.get("read_only", False)
         node_history = SQLiteNodeHistory(db_path, read_only)
 
-        node_history.create_timeout = config.get("boot_timeout", 3600)
-        node_history.last_match_timeout = config.get("idle_timeout", 300)
-
         return node_history
 
     def read_jobs_and_nodes(

--- a/src/hpc/autoscale/job/schedulernode.py
+++ b/src/hpc/autoscale/job/schedulernode.py
@@ -91,7 +91,7 @@ class TempNode(Node):
             self=self,
             node_id=DelayedNodeId(ht.NodeName(hostname)),
             name=ht.NodeName(hostname),
-            nodearray=ht.NodeArrayName("unknown"),
+            nodearray=ht.NodeArrayName(overrides.get("nodearray", "unknown")),
             bucket_id=bucket_id or ht.BucketId(str(uuid4())),
             hostname=ht.Hostname(hostname),
             private_ip=None,

--- a/src/hpc/autoscale/node/nodemanager.py
+++ b/src/hpc/autoscale/node/nodemanager.py
@@ -1423,6 +1423,10 @@ def _new_node_manager_79(
 
                 bucket_id = bucket.bucket_id
 
+                for n in nodes_list.nodes:
+                    ov = autoscale_config.get("_node-overrides", {})
+                    n.update(ov.get(n.get(""), {}))
+
                 # TODO the bucket has a list of node names
                 cc_node_records = [
                     n
@@ -1434,7 +1438,7 @@ def _new_node_manager_79(
                 ]
 
                 family_limit: Union[_SpotLimit, _SharedLimit] = family_limits[vm_family]
-                
+
                 if nodearray.get("Interruptible"):
                     # enabling spot/interruptible 0's out the family limit response
                     # as the regional limit is supposed to be used in its place,

--- a/src/hpc/autoscale/util.py
+++ b/src/hpc/autoscale/util.py
@@ -350,7 +350,9 @@ def parse_boot_timeout(config: Dict, node: Optional["Node"] = None) -> int:
     return parse_timeout("boot_timeout", 1800, config, node)
 
 
-def parse_timeout(timeout_key: str, default_value: int, config: Dict, node: Optional["Node"] = None) -> int:
+def parse_timeout(
+    timeout_key: str, default_value: int, config: Dict, node: Optional["Node"] = None
+) -> int:
     value: Union[int, str, Dict] = config.get(timeout_key, default_value)
     if isinstance(value, int):
         return value

--- a/src/hpc/autoscale/util.py
+++ b/src/hpc/autoscale/util.py
@@ -340,3 +340,31 @@ def is_standalone_dns(node_or_bucket: Union["Node", "NodeBucket"]) -> bool:
         .get("standalone_dns", {})
         .get("enabled", True)
     )
+
+
+def parse_idle_timeout(config: Dict, node: Optional["Node"] = None) -> int:
+    return parse_timeout("idle_timeout", 300, config, node)
+
+
+def parse_boot_timeout(config: Dict, node: Optional["Node"] = None) -> int:
+    return parse_timeout("boot_timeout", 1800, config, node)
+
+
+def parse_timeout(timeout_key: str, default_value: int, config: Dict, node: Optional["Node"] = None) -> int:
+    value: Union[int, str, Dict] = config.get(timeout_key, default_value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value)
+    section = node.nodearray if node else "default"
+    key = section
+    if key not in value:
+        key = "default"
+    if key not in value:
+        return default_value
+    ret = value.get(key)
+    if not ret:
+        return default_value
+    if isinstance(ret, str):
+        return int(ret)
+    return ret

--- a/test/hpc/autoscale/job/demandcalculator_test.py
+++ b/test/hpc/autoscale/job/demandcalculator_test.py
@@ -36,7 +36,7 @@ def teardown_function(function) -> None:
 @pytest.mark.skip
 def test_no_buckets():
     node_mgr = NodeManager(MockClusterBinding(), [])
-    dc = DemandCalculator(
+    dc = DemandCalculator({},
         node_mgr, NullNodeHistory(), singleton_lock=util.NullSingletonLock()
     )
     result = dc._add_job(Job("1", {"ncpus": 2}))

--- a/test/hpc/autoscale/job/demandcalculator_test.py
+++ b/test/hpc/autoscale/job/demandcalculator_test.py
@@ -36,8 +36,8 @@ def teardown_function(function) -> None:
 @pytest.mark.skip
 def test_no_buckets():
     node_mgr = NodeManager(MockClusterBinding(), [])
-    dc = DemandCalculator({},
-        node_mgr, NullNodeHistory(), singleton_lock=util.NullSingletonLock()
+    dc = DemandCalculator(
+        {}, node_mgr, NullNodeHistory(), singleton_lock=util.NullSingletonLock()
     )
     result = dc._add_job(Job("1", {"ncpus": 2}))
     assert not result

--- a/test/hpc/autoscale/node/nodehistory_test.py
+++ b/test/hpc/autoscale/node/nodehistory_test.py
@@ -1,0 +1,156 @@
+from hashlib import md5
+from typing import List, Optional
+
+from hpc.autoscale import hpctypes as ht
+from hpc.autoscale.node.delayednodeid import DelayedNodeId
+from hpc.autoscale.node.node import Node
+from hpc.autoscale.node.nodehistory import SQLiteNodeHistory
+
+
+class EasyNode(Node):
+    def __init__(
+        self,
+        name: ht.NodeName,
+        node_id: Optional[DelayedNodeId] = None,
+        nodearray: ht.NodeArrayName = ht.NodeArrayName("execute"),
+        bucket_id: Optional[ht.BucketId] = None,
+        hostname: Optional[ht.Hostname] = None,
+        private_ip: Optional[ht.IpAddress] = None,
+        instance_id: Optional[ht.InstanceId] = None,
+        vm_size: ht.VMSize = ht.VMSize("Standard_F4"),
+        location: ht.Location = ht.Location("westus"),
+        spot: bool = False,
+        vcpu_count: int = 4,
+        memory: ht.Memory = ht.Memory.value_of("8g"),
+        infiniband: bool = False,
+        state: ht.NodeStatus = ht.NodeStatus("Off"),
+        target_state: ht.NodeStatus = ht.NodeStatus("Off"),
+        power_state: ht.NodeStatus = ht.NodeStatus("off"),
+        exists: bool = False,
+        placement_group: Optional[ht.PlacementGroup] = None,
+        managed: bool = True,
+        resources: ht.ResourceDict = ht.ResourceDict({}),
+        software_configuration: dict = {},
+        keep_alive: bool = False,
+        gpu_count: Optional[int] = None,
+    ) -> None:
+
+        Node.__init__(
+            self,
+            name=name,
+            nodearray=nodearray,
+            hostname=hostname,
+            node_id=node_id or DelayedNodeId(name),
+            bucket_id=bucket_id or "b1",
+            private_ip=private_ip,
+            instance_id=instance_id,
+            vm_size=vm_size,
+            location=location,
+            spot=spot,
+            vcpu_count=vcpu_count,
+            memory=memory,
+            infiniband=infiniband,
+            state=state,
+            target_state=target_state,
+            power_state=power_state,
+            exists=exists,
+            placement_group=placement_group,
+            managed=managed,
+            resources=resources,
+            software_configuration=software_configuration,
+            keep_alive=keep_alive,
+            gpu_count=gpu_count,
+        )
+
+
+def new_booting_node(
+    name: str,
+    nodearray: str = "execute",
+    keep_alive=False,
+    state: str = "Acquiring",
+    instance_id_suffix: str = "",
+) -> Node:
+    name = ht.NodeName(name)
+    nodearray = ht.NodeArrayName(nodearray)
+    return EasyNode(
+        name=name,
+        nodearray=nodearray,
+        hostname=ht.Hostname("host" + name),
+        node_id=DelayedNodeId(
+            name=name,
+            node_id=ht.NodeId(md5(name.encode()).hexdigest()),
+            operation_id="op-1",
+            operation_offset=0,
+        ),
+        exists=True,
+        infiniband=False,
+        instance_id=ht.InstanceId(
+            md5(f"inst-{name}".encode()).hexdigest() + instance_id_suffix
+        ),
+        keep_alive=keep_alive,
+        state=ht.NodeStatus(state),
+        target_state=ht.NodeStatus("Started"),
+        power_state=ht.NodeStatus("on"),
+    )
+
+
+class SQLiteNodeHistoryMockClock(SQLiteNodeHistory):
+    def __init__(self, path: str = "nodehistory.db", read_only: bool = False) -> None:
+        super().__init__(path, read_only)
+
+        self.mock_now = 0.0
+
+    def now(self) -> float:
+        return self.mock_now
+
+
+def test_ready_time() -> None:
+    db = SQLiteNodeHistoryMockClock(":memory:")
+    db.mock_now = 1000
+
+    def nodes(state: str, instance_id_suffix: str = "") -> List[Node]:
+        return [
+            new_booting_node("e-1", state=state, instance_id_suffix=instance_id_suffix),
+            new_booting_node("e-2", state=state, instance_id_suffix=instance_id_suffix),
+            new_booting_node("e-3", state=state, instance_id_suffix=instance_id_suffix),
+        ]
+
+    # create 3 nodes at t=1000
+    db.update(nodes("Acquiring"))
+    assert 0 == len(db.find_booting(for_at_least=1800))
+    db.mock_now += 1801
+    assert db.now() == db.mock_now
+
+    # at t=2801, the 3 nodes have now failed to boot
+    assert 3 == len(db.find_booting(for_at_least=1800))
+    db.mock_now = 1000
+
+    # quick test that we can turn back time
+    assert 0 == len(db.find_booting(for_at_least=1800))
+
+    # now at t=4000, they again have timed out
+    db.mock_now += 3000
+    assert 3 == len(db.find_booting(for_at_least=1800))
+    # change their state to Ready and the timeout does not apply
+    db.update(nodes("Ready"))
+
+    assert 0 == len(db.find_booting(for_at_least=1800))
+
+    # BUG: if the node reverted to acquiring or any non-Ready state,
+    # we would report the node as a boot timeout
+    # however, since this node at least one time was ready, it should be fine.
+    db.update(nodes("Acquiring"))
+    assert 0 == len(db.find_booting(for_at_least=1800))
+
+    # ok, so if the node has been stuck in acquiring for all this time,
+    # we STILL do not consider it timed out, unless the instance id changed
+    db.mock_now += 3000
+    assert 0 == len(db.find_booting(for_at_least=1800))
+
+    # the instance id changed... which RESTARTS the timer!
+    db.update(nodes("Acquiring", instance_id_suffix="-2"))
+    assert 0 == len(db.find_booting(for_at_least=1800))
+
+    # Now they really have timed out
+    db.mock_now += 3000
+    assert 3 == len(db.find_booting(for_at_least=1800))

--- a/test/hpc/autoscale/util_test.py
+++ b/test/hpc/autoscale/util_test.py
@@ -14,6 +14,8 @@ from hpc.autoscale.util import (
     is_valid_hostname,
     load_config,
     new_singleton_lock,
+    parse_idle_timeout,
+    parse_boot_timeout,
     partition,
     partition_single,
 )
@@ -237,3 +239,16 @@ def test_is_valid_hostname() -> None:
     _invalid("ip-0A0100100", True, "ip-0A0100109")
     _valid("ip-0A0100100", True, "ip-0A0100109", "ip-0A0100100")
     _valid("ip-0A0100100", True, "^ip-[0-9A-Za-z]{9}$")
+
+
+def test_timeouts() -> None:
+    node = TempNode("localhost", nodearray="hpc")
+    assert 500 == parse_idle_timeout({"idle_timeout": {"default": 500}}, node)
+    assert 200 == parse_idle_timeout({"idle_timeout": {"default": 500, "hpc": 200}}, node)
+    assert 300 == parse_idle_timeout({"idle_timeout": {}}, node)
+    assert 600 == parse_idle_timeout({"idle_timeout": 600}, node)
+
+    assert 500 == parse_boot_timeout({"boot_timeout": {"default": 500}}, node)
+    assert 200 == parse_boot_timeout({"boot_timeout": {"default": 500, "hpc": 200}}, node)
+    assert 1800 == parse_boot_timeout({"boot_timeout": {}}, node)
+    assert 600 == parse_boot_timeout({"boot_timeout": 600}, node)

--- a/test/hpc/autoscale/util_test.py
+++ b/test/hpc/autoscale/util_test.py
@@ -14,8 +14,8 @@ from hpc.autoscale.util import (
     is_valid_hostname,
     load_config,
     new_singleton_lock,
-    parse_idle_timeout,
     parse_boot_timeout,
+    parse_idle_timeout,
     partition,
     partition_single,
 )
@@ -244,11 +244,15 @@ def test_is_valid_hostname() -> None:
 def test_timeouts() -> None:
     node = TempNode("localhost", nodearray="hpc")
     assert 500 == parse_idle_timeout({"idle_timeout": {"default": 500}}, node)
-    assert 200 == parse_idle_timeout({"idle_timeout": {"default": 500, "hpc": 200}}, node)
+    assert 200 == parse_idle_timeout(
+        {"idle_timeout": {"default": 500, "hpc": 200}}, node
+    )
     assert 300 == parse_idle_timeout({"idle_timeout": {}}, node)
     assert 600 == parse_idle_timeout({"idle_timeout": 600}, node)
 
     assert 500 == parse_boot_timeout({"boot_timeout": {"default": 500}}, node)
-    assert 200 == parse_boot_timeout({"boot_timeout": {"default": 500, "hpc": 200}}, node)
+    assert 200 == parse_boot_timeout(
+        {"boot_timeout": {"default": 500, "hpc": 200}}, node
+    )
     assert 1800 == parse_boot_timeout({"boot_timeout": {}}, node)
     assert 600 == parse_boot_timeout({"boot_timeout": 600}, node)


### PR DESCRIPTION
Add remove_nodes --permanent (and join_nodes --include-permanent) so that nodes can be removed from the cluster without fear of them being added to the cluster again
Improved handling of per-nodearray boot and idle timeouts.
Added addition validation step to allow implementations to clean up nodes before demand calculations.