### PR TITLE
Feature/by req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ setup(
     package_dir={"": "src", "conf": "conf"},
     include_package_data=True,
     install_requires=[
-        "requests >= 2.24.0",
+        "requests == 2.24.0",
         "typing_extensions",
         "immutabledict==1.0.0",
         "jsonpickle==1.4.1",

--- a/src/hpc/autoscale/ccbindings/interface.py
+++ b/src/hpc/autoscale/ccbindings/interface.py
@@ -29,7 +29,7 @@ class ClusterBindingInterface(ABC):
         ...
 
     @abc.abstractmethod
-    def create_nodes(self, nodes: List[node.Node]) -> NodeCreationResult:
+    def create_nodes(self, nodes: List[node.Node], request_id: Optional[str]) -> NodeCreationResult:
         pass
 
     @abc.abstractmethod
@@ -97,7 +97,8 @@ class ClusterBindingInterface(ABC):
         node_ids: Optional[List[NodeId]] = None,
         hostnames: Optional[List[Hostname]] = None,
         ip_addresses: Optional[List[IpAddress]] = None,
-        custom_filter: str = None,
+        custom_filter: Optional[str] = None,
+        request_id: Optional[str] = None,
     ) -> NodeManagementResult:
         pass
 

--- a/src/hpc/autoscale/ccbindings/legacy.py
+++ b/src/hpc/autoscale/ccbindings/legacy.py
@@ -76,7 +76,7 @@ class ClusterBinding(ClusterBindingInterface):
         return self.__cluster_name
 
     @hpcwrap
-    def create_nodes(self, nodes: List[Node]) -> NodeCreationResult:
+    def create_nodes(self, nodes: List[Node], request_id: Optional[str] = None) -> NodeCreationResult:
         if self.read_only:
             ret = NodeCreationResult()
             ret.operation_id = str(uuid.uuid4())
@@ -91,6 +91,7 @@ class ClusterBinding(ClusterBindingInterface):
 
         creation_request = NodeCreationRequest()
         creation_request.sets = []
+        creation_request.request_id = request_id
         # the node attributes aren't hashable, so a string representation
         # is good enough to ensure they are all the same across the list.
         p_nodes_dict = partition(
@@ -122,7 +123,7 @@ class ClusterBinding(ClusterBindingInterface):
             request_set.placement_group_id = pg
             request_set.definition = NodeCreationRequestSetDefinition()
             request_set.definition.machine_type = vm_size
-
+            
             if p_nodes[0].node_attribute_overrides:
                 request_set.node_attributes = deepcopy(
                     p_nodes[0].node_attribute_overrides

--- a/src/hpc/autoscale/ccbindings/mock.py
+++ b/src/hpc/autoscale/ccbindings/mock.py
@@ -326,12 +326,15 @@ class MockClusterBinding(ClusterBindingInterface):
 
         return self.nodes[name]
 
-    def create_nodes(self, new_nodes: List[Node]) -> NodeCreationResult:
+    def create_nodes(
+        self, new_nodes: List[Node], request_id: Optional[str] = None
+    ) -> NodeCreationResult:
         for node in new_nodes:
             assert node.name not in self.nodes, "{} already in {}".format(
                 node.name, list(self.nodes)
             )
             self.nodes[node.name] = node.clone()
+            self.nodes[node.name].metadata["__request_id__"] = request_id
 
             for bucket in self._get_buckets(node.location, node.vm_family):
                 if bucket.bucket_id == node.bucket_id:
@@ -478,7 +481,8 @@ class MockClusterBinding(ClusterBindingInterface):
         node_ids: Optional[List[NodeId]] = None,
         hostnames: Optional[List[Hostname]] = None,
         ip_addresses: Optional[List[IpAddress]] = None,
-        custom_filter: str = None,
+        custom_filter: Optional[str] = None,
+        request_id: Optional[str] = None,
     ) -> NodeManagementResult:
         raise NotImplementedError()
 

--- a/src/hpc/autoscale/node/nodemanager.py
+++ b/src/hpc/autoscale/node/nodemanager.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union
 from cyclecloud.model.ClusterStatusModule import ClusterStatus
 from cyclecloud.model.NodearrayBucketStatusModule import NodearrayBucketStatus
 from cyclecloud.model.NodeCreationResultModule import NodeCreationResult
+from cyclecloud.model.NodeListModule import NodeList
 from cyclecloud.model.NodeManagementResultModule import NodeManagementResult
 from cyclecloud.model.NodeManagementResultNodeModule import NodeManagementResultNode
 from cyclecloud.model.PlacementGroupStatusModule import PlacementGroupStatus
@@ -667,10 +668,20 @@ class NodeManager:
         return partition_single(self.get_buckets(), lambda b: b.bucket_id)
 
     @apitrace
+    def get_nodes_by_request_id(self, request_id: ht.RequestId) -> List[Node]:
+        relevant_node_list = self.__cluster_bindings.get_nodes(
+            request_id=request_id
+        )
+        return self._get_nodes_by_id(relevant_node_list)
+
+    @apitrace
     def get_nodes_by_operation(self, operation_id: ht.OperationId) -> List[Node]:
         relevant_node_list = self.__cluster_bindings.get_nodes(
             operation_id=operation_id
         )
+        return self._get_nodes_by_id(relevant_node_list)
+
+    def _get_nodes_by_id(self, relevant_node_list: NodeList) -> List[Node]:
         relevant_node_names = [n["Name"] for n in relevant_node_list.nodes]
         updated_cluster_status = self.__cluster_bindings.get_cluster_status(True)
 

--- a/src/hpc/autoscale/results.py
+++ b/src/hpc/autoscale/results.py
@@ -244,13 +244,13 @@ class NodeOperationResult(Result):
         self,
         status: str,
         operation_id: ht.OperationId,
-        request_id: Optional[ht.RequestId],
+        request_ids: Optional[List[ht.RequestId]],
         nodes: Optional[List["Node"]] = None,
         reasons: Reasons = None,
     ) -> None:
         Result.__init__(self, status, reasons)
         self.operation_id = operation_id
-        self.request_id = request_id
+        self.request_ids = request_ids
         self.nodes = nodes
         fire_result_handlers(self)
 


### PR DESCRIPTION
Allow two different request ids during node_mgr.bootup - one for creating new nodes, one for starting them.

Allow node_mgr.get_nodes_by_request_id()