### PR TITLE
Regress certifi version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ setup(
         "immutabledict==1.0.0",
         "jsonpickle==1.4.1",
         "argcomplete==1.12.2",
-        "certifi==2022.12.07",
+        "certifi==2020.12.5",
         "importlib-metadata<4",
     ]
     + ["urllib3==1.25.11"],  # noqa: W503


### PR DESCRIPTION
it needs to be not later than 2020.12.5 to be
compatible with azlurm 3.0.1.
