### PR TITLE
Mitigations for missing VM Size info in locked down environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,32 @@ You can also set these per nodearray.
 ```"idle_timeout": {"default": 300, "nodearray1": 600, "nodearray2": 900},
    "boot_timeout": {"default": 3600, "nodearray1": 7200, "nodearray2": 900},
 ```
+
+# Incorrect VM Size Information
+In some regions or subscriptions, CycleCloud cannot get the proper VM Size information for all VM Sizes. Often this results in an incorrect number of GPUs being reported, otherwise all attributes are incorrect. By default, as of 1.0.2, an internal record of all public regions and vm_sizes - `hpc/autoscale/node/vm_sizes.json` - will fallback on a common US region for US Gov/DOD regions. 
+
+At the top of this file, you will find the following
+```json
+{
+  "proxied-locations": {
+    "_comment_": "This is a mapping of locations that are not available in the Azure API, but are proxied to another location.",
+    "usdodcentral": "southcentralus",
+    "usdodeast": "southcentralus",
+    "usdodtexas": "southcentralus",
+    "usgovarizona": "southcentralus",
+    "usgoviowa": "southcentralus",
+    "usgovtexas": "southcentralus",
+    "usgovvirginia": "southcentralus",
+    "usseceast": "southcentralus",
+    "ussecwest": "southcentralus"
+  },
+```
+
+This states that for these locations we should just use the data on hand for southcentralus. A user can modify this however they want after installation, there is no requirement that these map to southcentralus.
+
+_Note_ Please remember that you can also always define a `default_resource` for your gpu resource with an explicit integer. This is the preferred way to deal with this issue, however this can become painful when dealing with many VM Sizes that are simply missing basic information.
+
+Lastly, it should be noted that if the GPUs defined in this file are higher than CycleCloud reports, then this file takes precedence. This is due to the subscription that CycleCloud is using is being told that the VM Size has 0 GPUs in some locked down regions when the GPU count should be higher.
     
 
 # Contributing

--- a/src/hpc/autoscale/ccbindings/mock.py
+++ b/src/hpc/autoscale/ccbindings/mock.py
@@ -149,6 +149,7 @@ class MockClusterBinding(ClusterBindingInterface):
         assert aux_info.vm_family != "unknown", vm_size
 
         vcpu_count = aux_info.vcpu_count
+        gpu_count = aux_info.gpu_count
 
         bucket_status = NodearrayBucketStatus()
         bucket_status.valid = valid
@@ -204,6 +205,7 @@ class MockClusterBinding(ClusterBindingInterface):
         bucket_status.definition.machine_type = vm_size
         bucket_status.virtual_machine = NodearrayBucketStatusVirtualMachine()
         bucket_status.virtual_machine.vcpu_count = vcpu_count
+        bucket_status.virtual_machine.gpu_count = gpu_count
         bucket_status.virtual_machine.memory = aux_info.memory.convert_to("g").value
 
         bucket_status.virtual_machine.infiniband = aux_info.infiniband

--- a/src/hpc/autoscale/node/bucket.py
+++ b/src/hpc/autoscale/node/bucket.py
@@ -33,6 +33,7 @@ class NodeDefinition:
         spot: bool,
         subnet: ht.SubnetId,
         vcpu_count: int,
+        gpu_count: int,
         memory: ht.Memory,
         placement_group: Optional[ht.PlacementGroup],
         resources: ht.ResourceDict,
@@ -52,6 +53,8 @@ class NodeDefinition:
         self.subnet = subnet
         assert vcpu_count is not None
         self.vcpu_count = vcpu_count
+        assert gpu_count is not None
+        self.gpu_count = gpu_count
         assert memory is not None
         assert isinstance(memory, ht.Memory), "expected Memory, got {}".format(
             type(memory)
@@ -117,6 +120,7 @@ class NodeBucket:
             location=self.location,
             spot=definition.spot,
             vcpu_count=self.vcpu_count,
+            gpu_count=definition.gpu_count,
             memory=self.memory,
             infiniband=False,
             state=ht.NodeStatus("Off"),

--- a/src/hpc/autoscale/node/node.py
+++ b/src/hpc/autoscale/node/node.py
@@ -108,8 +108,8 @@ class Node(ABC):
         self.__create_time = self.__last_match_time = self.__delete_time = 0.0
         self.__create_time_remaining = self.__idle_time_remaining = 0.0
         self.__keep_alive = keep_alive
-        self.__gpu_count = (
-            gpu_count if gpu_count is not None else self.__aux_vm_info.gpu_count
+        self.__gpu_count = max(
+            gpu_count if gpu_count is not None else 0, self.__aux_vm_info.gpu_count
         )
         self.name_format: Optional[str] = None  # f"{self.nodearray}-%s"
         self.name_offset: Optional[int] = None

--- a/src/hpc/autoscale/node/nodemanager.py
+++ b/src/hpc/autoscale/node/nodemanager.py
@@ -642,6 +642,7 @@ class NodeManager:
                 spot=False,
                 subnet=ht.SubnetId("unknown"),
                 vcpu_count=a_node.vcpu_count,
+                gpu_count=a_node.gpu_count,
                 memory=a_node.memory,
                 placement_group=placement_group,
                 resources=ht.ResourceDict(dict(deepcopy(a_node.resources))),
@@ -1417,6 +1418,8 @@ def _new_node_manager_79(
                 continue
 
             vcpu_count = bucket.virtual_machine.vcpu_count
+            gpu_count = bucket.virtual_machine.gpu_count
+            assert gpu_count is not None
 
             aux_vm_info = vm_sizes.get_aux_vm_size_info(
                 region, bucket.definition.machine_type
@@ -1570,6 +1573,7 @@ def _new_node_manager_79(
                     spot=spot,
                     subnet=subnet,
                     vcpu_count=vcpu_count,
+                    gpu_count=gpu_count,
                     memory=bucket_memory,
                     placement_group=pg_name,
                     resources=custom_resources,

--- a/src/hpc/autoscale/node/vm_sizes.py
+++ b/src/hpc/autoscale/node/vm_sizes.py
@@ -89,7 +89,17 @@ __AUX_CACHE = {}
 
 @_initialize
 def get_aux_vm_size_info(location: str, vm_size: str) -> AuxVMSizeInfo:
+    if location not in VM_SIZES:
+        proxied_location = VM_SIZES.get("proxied-locations", {}).get(location)
+        logging.debug("Using proxied-location %s instead of %s to get auxiliary VM Size information for %s",
+                    proxied_location,
+                    location,
+                    vm_size)
+        if proxied_location:
+            location = proxied_location
+
     key = (location, vm_size)
+
     if key not in __AUX_CACHE:
         by_name = VM_SIZES.get(location)
 

--- a/util/create_vm_sizes.py
+++ b/util/create_vm_sizes.py
@@ -9,6 +9,20 @@ from hpc.autoscale.node.vm_sizes import AuxVMSizeInfo
 from hpc.autoscale.util import partition, partition_single
 
 
+PROXIED_LOCATIONS = {
+    "_comment_": "This is a mapping of locations that are not available in the Azure API, but are proxied to another location.",
+    "usdodcentral": "southcentralus",
+    "usdodeast": "southcentralus",
+    "usdodtexas": "southcentralus",
+    "usgovarizona": "southcentralus",
+    "usgoviowa": "southcentralus",
+    "usgovtexas": "southcentralus",
+    "usgovvirginia": "southcentralus",
+    "usseceast": "southcentralus",
+    "ussecwest": "southcentralus",
+}
+
+
 def create_vm_sizes(cache_path: Optional[str] = None) -> None:
 
     if cache_path and os.path.exists(cache_path):
@@ -145,7 +159,8 @@ def create_vm_sizes(cache_path: Optional[str] = None) -> None:
         if row["Location"] not in vm_sizes:
             vm_sizes[row["Location"]] = {}
 
-    final_vm_sizes: Dict = {}
+    final_vm_sizes: Dict = {"proxied-locations": PROXIED_LOCATIONS}
+    
     for loc in sorted(vm_sizes):
         final_vm_sizes[loc] = loc_dict = {}
         for vm_size in sorted(vm_sizes[loc]):
@@ -158,7 +173,7 @@ def create_vm_sizes(cache_path: Optional[str] = None) -> None:
         old_data = json.load(fr)
 
     missing_locations = set(old_data.keys()) - set(final_vm_sizes.keys())
-    new_locations = set(final_vm_sizes.keys()) - set(old_data.keys())
+    new_locations = set(final_vm_sizes.keys()) - set(old_data.keys()) - set(["proxied-locations"])
     if missing_locations:
         print("WARNING: Missing locations:", ",".join(missing_locations))
     if missing_locations:


### PR DESCRIPTION
Added a new "proxied-locations" section to the vm_sizes.json. 
Also, we now use the max(CycleCloud reported GPUs, vm_sizes.json reported GPUs), so that if CycleCloud reports 0 gpus we will always override it with the vm_sizes.json, not simply when null/None is reported from CycleCloud.

Relevant new additions to the README

# Incorrect VM Size Information
In some regions or subscriptions, CycleCloud cannot get the proper VM Size information for all VM Sizes. Often this results in an incorrect number of GPUs being reported, otherwise all attributes are incorrect. By default, as of 1.0.2, an internal record of all public regions and vm_sizes - `hpc/autoscale/node/vm_sizes.json` - will fallback on a common US region for US Gov/DOD regions. 

At the top of this file, you will find the following
```json
{
  "proxied-locations": {
    "_comment_": "This is a mapping of locations that are not available in the Azure API, but are proxied to another location.",
    "usdodcentral": "southcentralus",
    "usdodeast": "southcentralus",
    "usdodtexas": "southcentralus",
    "usgovarizona": "southcentralus",
    "usgoviowa": "southcentralus",
    "usgovtexas": "southcentralus",
    "usgovvirginia": "southcentralus",
    "usseceast": "southcentralus",
    "ussecwest": "southcentralus"
  },
```

This states that for these locations we should just use the data on hand for southcentralus. A user can modify this however they want after installation, there is no requirement that these map to southcentralus.

_Note_ Please remember that you can also always define a `default_resource` for your gpu resource with an explicit integer. This is the preferred way to deal with this issue, however this can become painful when dealing with many VM Sizes that are simply missing basic information.

Lastly, it should be noted that if the GPUs defined in this file are higher than CycleCloud reports, then this file takes precedence. This is due to the subscription that CycleCloud is using is being told that the VM Size has 0 GPUs in some locked down regions when the GPU count should be higher.