### PR TITLE
set logging context to [command] by default

### DIFF
--- a/src/hpc/autoscale/clilib.py
+++ b/src/hpc/autoscale/clilib.py
@@ -1916,6 +1916,7 @@ def main(
                 }
             if args.nodes_response:
                 args.config["_mock_bindings"]["nodes_response"] = args.nodes_response
+        logging.set_context(f"[{args.cmd}]")
         logging.initialize_logging(args.config)
 
         # if applicable, set read_only/lock_file


### PR DESCRIPTION
Allows projects like azslurm to add %(context)s to their log statements, which will be filled with the name of the command, ie [scale] or [return_to_idle] etc.