### PR TITLE
Disable log rotation when current user != log owner

### DIFF
--- a/example-celery/project.ini
+++ b/example-celery/project.ini
@@ -1,7 +1,7 @@
 [project]
-version = 1.0.3
+version = 1.0.4
 type = application
 name = celery-autoscale-demo
 
 [blobs]
-Files = cyclecloud-scalelib-1.0.3.tar.gz 
+Files = cyclecloud-scalelib-1.0.4.tar.gz 

--- a/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
+++ b/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
@@ -12,7 +12,7 @@ CC_VERSION=$(jetpack config cyclecloud.cookbooks.version)
 wget --no-check-certificate ${cs_hostname}/static/tools/cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 pip install cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 
-jetpack download --project celery-autoscale-demo cyclecloud-scalelib-1.0.3.tar.gz $CYCLECLOUD_SPEC_PATH/files/
+jetpack download --project celery-autoscale-demo cyclecloud-scalelib-1.0.4.tar.gz $CYCLECLOUD_SPEC_PATH/files/
 pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-1.0.3.tar.gz
 
 LOGGING_CONF=$(python -c 'import hpc.autoscale, os; print(os.path.abspath(os.path.join(hpc.autoscale.__file__, "..", "logging.conf")))')

--- a/example-celery/templates/celery.txt
+++ b/example-celery/templates/celery.txt
@@ -17,7 +17,7 @@ Category = Applications
     Region = $Region
     KeyPairLocation = ~/.ssh/cyclecloud.pem
             
-        [[[cluster-init celery-autoscale-demo:default:1.0.3]]]
+        [[[cluster-init celery-autoscale-demo:default:1.0.4]]]
         Optional = True
 
         [[[configuration]]]
@@ -30,9 +30,9 @@ Category = Applications
     
         [[[configuration]]]
 
-        [[[cluster-init celery-autoscale-demo:broker:1.0.3]]]
+        [[[cluster-init celery-autoscale-demo:broker:1.0.4]]]
         Optional = True
-        [[[cluster-init celery-autoscale-demo:worker:1.0.3]]]
+        [[[cluster-init celery-autoscale-demo:worker:1.0.4]]]
         Optional = True
 
         [[[network-interface eth0]]]
@@ -55,7 +55,7 @@ Category = Applications
         [[[configuration]]]
         celery.broker.privateip = ${broker.instance.privateip}
 
-        [[[cluster-init celery-autoscale-demo:worker:1.0.3]]]
+        [[[cluster-init celery-autoscale-demo:worker:1.0.4]]]
         Optional = True
 
 

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ fi
 
 export PATH=$(python3 -c '
 import os
+
 paths = os.environ["PATH"].split(os.pathsep)
 cc_home = os.getenv("CYCLECLOUD_HOME", "/opt/cycle/jetpack")
 print(os.pathsep.join(

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-CYCLECLOUD_SCALELIB_VERSION = "1.0.3"
+CYCLECLOUD_SCALELIB_VERSION = "1.0.4"
 CYCLECLOUD_API_VERSION = "8.1.0"
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.test import test as TestCommand  # noqa: N812
 
 import inspect
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 SWAGGER_URL = "https://oss.sonatype.org/content/repositories/releases/io/swagger/swagger-codegen-cli/2.2.1/swagger-codegen-cli-2.2.1.jar"
 SWAGGER_CLI = SWAGGER_URL.split("/")[-1]

--- a/test/hpc/autoscale/hpclogging_test.py
+++ b/test/hpc/autoscale/hpclogging_test.py
@@ -1,0 +1,54 @@
+from hpc.autoscale import hpclogging
+import logging.handlers
+import os
+from typing import Tuple
+import tempfile
+
+
+class MockFileOwnerHandler:
+    def __init__(self, path: str, uid: int, gid: int):
+        self.path = path
+        self.uid = uid
+        self.gid = gid
+
+    def __call__(self, path: str) -> Tuple[int, int]:
+        assert path == self.path
+        return self.uid, self.gid
+
+def test_disable_log_rotation():
+    path = tempfile.mktemp()
+    # wrong uid/gid
+    with open(path, "w"):
+        pass
+    try:
+        mock_fh = MockFileOwnerHandler(path, os.getuid() + 1, os.getgid() + 1)
+        logger = hpclogging.HPCLogger("test", file_owner_handler=mock_fh)
+        handler = logging.handlers.RotatingFileHandler(path, maxBytes=1000)
+        # we will see a mismatch, so we will set maxBytes to 2^32 and log a warning
+        logger.addHandler(handler)
+        assert handler.maxBytes == 2**32
+        assert logger.non_rotated_files == [path]
+        logger.info("test")
+        assert not logger.non_rotated_files
+        handler.close()
+        assert f"The following logs will not be rotated because the current user does not match the owner: {path}\ntest" == open(path).read().strip()
+    finally:
+        os.remove(path)
+
+    # correct uid/gid
+    with open(path, "w"):
+        pass
+    try:
+        mock_fh = MockFileOwnerHandler(path, os.getuid(), os.getgid())
+        logger = hpclogging.HPCLogger("test", file_owner_handler=mock_fh)
+        handler = logging.handlers.RotatingFileHandler(path, maxBytes=1000)
+        # happy path - we do not touch maxBytes and there are no warnings
+        logger.addHandler(handler)
+        assert handler.maxBytes == 1000
+        assert logger.non_rotated_files == []
+        logger.info("test")
+        assert not logger.non_rotated_files
+        handler.close()
+        assert f"test" == open(path).read().strip()
+    finally:
+        os.remove(path)


### PR DESCRIPTION
Users will run a command that causes a rotation as a different user than the log was originally created, causing permissions issues for service accounts.