### PR TITLE
Add last_capacity_failure support for spots

### DIFF
--- a/src/hpc/autoscale/clilib.py
+++ b/src/hpc/autoscale/clilib.py
@@ -1183,7 +1183,7 @@ class CommonCLI(ABC):
             config, writer.getvalue(), node_mgr.get_buckets()
         )
 
-        demand_result = DemandResult([], [f.example_node for f in filtered], [], [])
+        demand_result = DemandResult([], [f.example_node for f in filtered], [], [], node_mgr.get_buckets())
 
         config["output_columns"] = output_columns
 

--- a/src/hpc/autoscale/job/demand.py
+++ b/src/hpc/autoscale/job/demand.py
@@ -1,7 +1,10 @@
-from typing import List
+from typing import Dict, List
 
 from hpc.autoscale.codeanalysis import hpcwrapclass
+from hpc.autoscale.hpctypes import BucketId
 from hpc.autoscale.node.node import Node
+from hpc.autoscale.node.bucket import NodeBucket
+from hpc.autoscale.util import partition
 
 
 @hpcwrapclass
@@ -16,12 +19,15 @@ class DemandResult:
         matched_nodes: List[Node],
         unmatched_nodes: List[Node],
         failed_nodes: List[Node],
+        buckets: List[NodeBucket],
     ) -> None:
         self.new_nodes = new_nodes
         self.matched_nodes = matched_nodes
         self.unmatched_nodes = unmatched_nodes
         self.failed_nodes = failed_nodes
         self.compute_nodes = matched_nodes + unmatched_nodes
+        self.buckets = buckets
+        self.buckets_by_id = partition(self.buckets, lambda b: b.bucket_id)
         for node in self.failed_nodes:
             if node not in self.compute_nodes:
                 self.compute_nodes.append(node)

--- a/src/hpc/autoscale/job/demandcalculator.py
+++ b/src/hpc/autoscale/job/demandcalculator.py
@@ -215,6 +215,7 @@ class DemandCalculator:
             required_nodes,
             unrequired_nodes,
             self.node_mgr.get_failed_nodes(),
+            buckets=self.node_mgr.get_buckets(),
         )
 
     @apitrace

--- a/src/hpc/autoscale/job/demandprinter.py
+++ b/src/hpc/autoscale/job/demandprinter.py
@@ -186,6 +186,13 @@ class DemandPrinter:
                         value = node.resources.get(column)
                     else:
                         value = node.metadata.get(column)
+                    
+                    if value is None:
+                        buckets = demand_result.buckets_by_id.get(node.bucket_id, [])
+                        if buckets:
+                            bucket = buckets[0]
+                            if hasattr(bucket, column):
+                                value = getattr(bucket, column)
 
                 if value is None:
                     value = self.__defaults.get(column)

--- a/src/hpc/autoscale/node/bucket.py
+++ b/src/hpc/autoscale/node/bucket.py
@@ -91,6 +91,8 @@ class NodeBucket:
         max_placement_group_size: int,
         nodes: List["Node"],
         artificial: bool = False,
+        priority: int = 0,
+        last_capacity_failure: float = -1.0,
         valid: bool = True,
     ) -> None:
         # example node to be used to see if your job would match this
@@ -99,7 +101,8 @@ class NodeBucket:
         assert limits
         self.limits = limits
         self.max_placement_group_size = max_placement_group_size
-        self.priority = 0
+        self.priority = priority
+        self.__last_capacity_failure = last_capacity_failure
         # list of nodes cyclecloud currently says are in this bucket
         self.nodes = nodes
         self.__decrement_counter = 0
@@ -265,6 +268,11 @@ class NodeBucket:
     def valid(self) -> bool:
         return self._valid
 
+    def last_capacity_failure(self) -> Optional[float]:
+        if self.__last_capacity_failure < 0:
+            return None
+        return self.__last_capacity_failure
+
     def add_nodes(self, nodes: List["Node"]) -> None:
         assert self.valid
         new_by_id = partition(nodes, lambda n: n.delayed_node_id.transient_id)
@@ -326,7 +334,9 @@ class NodeBucket:
             self.max_placement_group_size,
             nodes=[],
             artificial=False,
-            valid=True,
+            priority=self.priority,
+            last_capacity_failure=self.__last_capacity_failure,
+            valid=True
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
When spot instances hit capacity failures, the bucket will be marked with the time of the last failure in seconds since epoch. There is also a new constraint that pushes a bucket with a recent (5 minutes by default) failure to the end of the priority list. As well, some tweaks were made so that bucket outputs are easier to see from the command line (via demand).