### PR TITLE
Only use builtin vm size gpu information if cyclecloud provided 0 or …

### DIFF
--- a/src/hpc/autoscale/node/node.py
+++ b/src/hpc/autoscale/node/node.py
@@ -108,9 +108,12 @@ class Node(ABC):
         self.__create_time = self.__last_match_time = self.__delete_time = 0.0
         self.__create_time_remaining = self.__idle_time_remaining = 0.0
         self.__keep_alive = keep_alive
-        self.__gpu_count = max(
-            gpu_count if gpu_count is not None else 0, self.__aux_vm_info.gpu_count
-        )
+        gpu_count = gpu_count if gpu_count is not None else 0
+        # only use the aux info if cyclecloud provided 0 gpus. We used to use a max() here
+        # but that prevented cyclecloud from fixing the raw data from azure, so we were overwriting
+        # the corrected data with data from the same source -rdh
+        self.__gpu_count = gpu_count if gpu_count > 0 else self.__aux_vm_info.gpu_count
+        
         self.name_format: Optional[str] = None  # f"{self.nodearray}-%s"
         self.name_offset: Optional[int] = None
 


### PR DESCRIPTION
…null gpu count

There are cases where CycleCloud attempts to repair invalid data from Azure - for example if Azure says that there are more GPUs than the VM size supports. Our previous versions would override what CycleCloud reported. Now we only fallback on our internal vm size information if CycleCloud reports null or 0 gpus, which is common in sovereign and gov clouds.