### PR TITLE
fix az nodes/limits bug

### DIFF
--- a/example-celery/project.ini
+++ b/example-celery/project.ini
@@ -1,7 +1,7 @@
 [project]
-version = 1.0.6
+version = 1.0.7
 type = application
 name = celery-autoscale-demo
 
 [blobs]
-Files = cyclecloud-scalelib-1.0.6.tar.gz 
+Files = cyclecloud-scalelib-1.0.7.tar.gz 

--- a/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
+++ b/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
@@ -12,8 +12,8 @@ CC_VERSION=$(jetpack config cyclecloud.cookbooks.version)
 wget --no-check-certificate ${cs_hostname}/static/tools/cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 pip install cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 
-jetpack download --project celery-autoscale-demo cyclecloud-scalelib-1.0.6.tar.gz $CYCLECLOUD_SPEC_PATH/files/
-pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-1.0.6.tar.gz
+jetpack download --project celery-autoscale-demo cyclecloud-scalelib-1.0.7.tar.gz $CYCLECLOUD_SPEC_PATH/files/
+pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-1.0.7.tar.gz
 
 LOGGING_CONF=$(python -c 'import hpc.autoscale, os; print(os.path.abspath(os.path.join(hpc.autoscale.__file__, "..", "logging.conf")))')
 cp $LOGGING_CONF $INSTALLDIR

--- a/example-celery/templates/celery.txt
+++ b/example-celery/templates/celery.txt
@@ -17,7 +17,7 @@ Category = Applications
     Region = $Region
     KeyPairLocation = ~/.ssh/cyclecloud.pem
             
-        [[[cluster-init celery-autoscale-demo:default:1.0.6]]]
+        [[[cluster-init celery-autoscale-demo:default:1.0.7]]]
         Optional = True
 
         [[[configuration]]]
@@ -30,9 +30,9 @@ Category = Applications
     
         [[[configuration]]]
 
-        [[[cluster-init celery-autoscale-demo:broker:1.0.6]]]
+        [[[cluster-init celery-autoscale-demo:broker:1.0.7]]]
         Optional = True
-        [[[cluster-init celery-autoscale-demo:worker:1.0.6]]]
+        [[[cluster-init celery-autoscale-demo:worker:1.0.7]]]
         Optional = True
 
         [[[network-interface eth0]]]
@@ -55,7 +55,7 @@ Category = Applications
         [[[configuration]]]
         celery.broker.privateip = ${broker.instance.privateip}
 
-        [[[cluster-init celery-autoscale-demo:worker:1.0.6]]]
+        [[[cluster-init celery-autoscale-demo:worker:1.0.7]]]
         Optional = True
 
 

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-CYCLECLOUD_SCALELIB_VERSION = "1.0.6"
+CYCLECLOUD_SCALELIB_VERSION = "1.0.7"
 CYCLECLOUD_API_VERSION = "8.1.0"
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.test import test as TestCommand  # noqa: N812
 
 import inspect
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 SWAGGER_URL = "https://oss.sonatype.org/content/repositories/releases/io/swagger/swagger-codegen-cli/2.2.1/swagger-codegen-cli-2.2.1.jar"
 SWAGGER_CLI = SWAGGER_URL.split("/")[-1]

--- a/src/hpc/autoscale/job/demand.py
+++ b/src/hpc/autoscale/job/demand.py
@@ -19,7 +19,7 @@ class DemandResult:
         matched_nodes: List[Node],
         unmatched_nodes: List[Node],
         failed_nodes: List[Node],
-        buckets: List[NodeBucket],
+        buckets: List[NodeBucket] = [],
     ) -> None:
         self.new_nodes = new_nodes
         self.matched_nodes = matched_nodes


### PR DESCRIPTION
demandresult object now makes the buckets parameter optional, fixing issues when running az* nodes or limits commands.