### PR TITLE
Add reimage and restart cli to CommonCli

### DIFF
--- a/src/hpc/autoscale/ccbindings/interface.py
+++ b/src/hpc/autoscale/ccbindings/interface.py
@@ -90,6 +90,30 @@ class ClusterBindingInterface(ABC):
         pass
 
     @abc.abstractmethod
+    def reimage_nodes(
+        self,
+        nodes: Optional[List[node.Node]] = None,
+        names: Optional[List[NodeName]] = None,
+        node_ids: Optional[List[NodeId]] = None,
+        hostnames: Optional[List[Hostname]] = None,
+        ip_addresses: Optional[List[IpAddress]] = None,
+        custom_filter: str = None,
+    ) -> NodeManagementResult:
+        pass
+
+    @abc.abstractmethod
+    def restart_nodes(
+        self,
+        nodes: Optional[List[node.Node]] = None,
+        names: Optional[List[NodeName]] = None,
+        node_ids: Optional[List[NodeId]] = None,
+        hostnames: Optional[List[Hostname]] = None,
+        ip_addresses: Optional[List[IpAddress]] = None,
+        custom_filter: str = None,
+    ) -> NodeManagementResult:
+        pass
+
+    @abc.abstractmethod
     def start_nodes(
         self,
         nodes: Optional[List[node.Node]] = None,

--- a/src/hpc/autoscale/ccbindings/legacy.py
+++ b/src/hpc/autoscale/ccbindings/legacy.py
@@ -283,6 +283,56 @@ class ClusterBinding(ClusterBindingInterface):
         self._log_response(http_response, result)
         return result
 
+    @notreadonly
+    def reimage_nodes(
+        self,
+        nodes: Optional[List[Node]] = None,
+        names: Optional[List[ht.NodeName]] = None,
+        node_ids: Optional[List[ht.NodeId]] = None,
+        hostnames: Optional[List[ht.Hostname]] = None,
+        ip_addresses: Optional[List[ht.IpAddress]] = None,
+        custom_filter: str = None,
+        request_id: Optional[str] = None,
+    ) -> NodeManagementResult:
+
+        request = self._node_management_request(
+            nodes, names, node_ids, hostnames, ip_addresses, custom_filter, request_id
+        )
+
+        logging.fine(json.dumps(request.to_dict()))
+
+        http_response, result = self.clusters_module.reimage_nodes(
+            self.session, self.cluster_name, request
+        )
+
+        self._log_response(http_response, result)
+        return result
+
+    @notreadonly
+    def restart_nodes(
+        self,
+        nodes: Optional[List[Node]] = None,
+        names: Optional[List[ht.NodeName]] = None,
+        node_ids: Optional[List[ht.NodeId]] = None,
+        hostnames: Optional[List[ht.Hostname]] = None,
+        ip_addresses: Optional[List[ht.IpAddress]] = None,
+        custom_filter: str = None,
+        request_id: Optional[str] = None,
+    ) -> NodeManagementResult:
+
+        request = self._node_management_request(
+            nodes, names, node_ids, hostnames, ip_addresses, custom_filter, request_id
+        )
+
+        logging.fine(json.dumps(request.to_dict()))
+
+        http_response, result = self.clusters_module.restart_nodes(
+            self.session, self.cluster_name, request
+        )
+
+        self._log_response(http_response, result)
+        return result
+
     @hpcwrap
     def start_nodes(
         self,

--- a/src/hpc/autoscale/ccbindings/mock.py
+++ b/src/hpc/autoscale/ccbindings/mock.py
@@ -424,6 +424,60 @@ class MockClusterBinding(ClusterBindingInterface):
         self.operations[result.operation_id] = result
         return result
 
+    def reimage_nodes(
+        self,
+        nodes: Optional[List[Node]] = None,
+        names: Optional[List[NodeName]] = None,
+        node_ids: Optional[List[NodeId]] = None,
+        hostnames: Optional[List[Hostname]] = None,
+        ip_addresses: Optional[List[IpAddress]] = None,
+        custom_filter: str = None,
+    ) -> NodeManagementResult:
+        if not names:
+            assert nodes
+            names = [n.name for n in nodes]
+            nodes = None
+
+        result_nodes: List[Node] = []
+        for name in names:
+            assert name in self.nodes
+            if name in self.nodes:
+                node = self.nodes[name]
+                node.state = NodeStatus("Reimaging")
+                node.target_state = NodeStatus("Started")
+                result_nodes.append(node)
+        result = MockNodeManagementResult(OperationId(str(uuid.uuid4())), result_nodes)
+        result.operation_id = OperationId(str(uuid.uuid4()))
+        self.operations[result.operation_id] = result
+        return result
+
+    def restart_nodes(
+        self,
+        nodes: Optional[List[Node]] = None,
+        names: Optional[List[NodeName]] = None,
+        node_ids: Optional[List[NodeId]] = None,
+        hostnames: Optional[List[Hostname]] = None,
+        ip_addresses: Optional[List[IpAddress]] = None,
+        custom_filter: str = None,
+    ) -> NodeManagementResult:
+        if not names:
+            assert nodes
+            names = [n.name for n in nodes]
+            nodes = None
+
+        result_nodes: List[Node] = []
+        for name in names:
+            assert name in self.nodes
+            if name in self.nodes:
+                node = self.nodes[name]
+                node.state = NodeStatus("Restarting")
+                node.target_state = NodeStatus("Started")
+                result_nodes.append(node)
+        result = MockNodeManagementResult(OperationId(str(uuid.uuid4())), result_nodes)
+        result.operation_id = OperationId(str(uuid.uuid4()))
+        self.operations[result.operation_id] = result
+        return result
+
     def deallocate_nodes(
         self,
         nodes: Optional[List[Node]] = None,

--- a/src/hpc/autoscale/ccbindings/mock.py
+++ b/src/hpc/autoscale/ccbindings/mock.py
@@ -447,7 +447,6 @@ class MockClusterBinding(ClusterBindingInterface):
                 node.target_state = NodeStatus("Started")
                 result_nodes.append(node)
         result = MockNodeManagementResult(OperationId(str(uuid.uuid4())), result_nodes)
-        result.operation_id = OperationId(str(uuid.uuid4()))
         self.operations[result.operation_id] = result
         return result
 
@@ -474,7 +473,6 @@ class MockClusterBinding(ClusterBindingInterface):
                 node.target_state = NodeStatus("Started")
                 result_nodes.append(node)
         result = MockNodeManagementResult(OperationId(str(uuid.uuid4())), result_nodes)
-        result.operation_id = OperationId(str(uuid.uuid4()))
         self.operations[result.operation_id] = result
         return result
 
@@ -595,7 +593,7 @@ class MockClusterBinding(ClusterBindingInterface):
         node_names = node_names or list(self.nodes.keys())
         for node_name in node_names:
             self.nodes[NodeName(node_name)].state = NodeStatus(state)
-                    
+
     def _next_ip(self) -> IpAddress:
         if self.last_used_ip[-1] == 255:
             self.last_used_ip[-1] = 1

--- a/src/hpc/autoscale/clilib.py
+++ b/src/hpc/autoscale/clilib.py
@@ -967,6 +967,42 @@ class CommonCLI(ABC):
             permanent=permanent,
         )
 
+    def reimage_nodes_parser(self, parser: ArgumentParser) -> None:
+        self._add_hostnames(parser)
+        self._add_nodenames(parser)
+        parser.set_defaults(read_only=False)
+
+    def reimage_nodes(
+        self,
+        config: Dict,
+        hostnames: List[str],
+        node_names: List[str],
+    ) -> None:
+        """Reimages the specified nodes."""
+        driver, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
+        result = demand_calc.node_mgr.reimage_nodes(nodes)
+        print("Reimaging the following nodes:")
+        for n in result.nodes or []:
+            print("   ", n)
+
+    def restart_nodes_parser(self, parser: ArgumentParser) -> None:
+        self._add_hostnames(parser)
+        self._add_nodenames(parser)
+        parser.set_defaults(read_only=False)
+
+    def restart_nodes(
+        self,
+        config: Dict,
+        hostnames: List[str],
+        node_names: List[str],
+    ) -> None:
+        """Restarts the specified nodes."""
+        driver, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
+        result = demand_calc.node_mgr.restart_nodes(nodes)
+        print("Restarting the following nodes:")
+        for n in result.nodes or []:
+            print("   ", n)
+
     def delete_nodes_parser(self, parser: ArgumentParser) -> None:
         self._add_hostnames(parser)
         self._add_nodenames(parser)

--- a/src/hpc/autoscale/clilib.py
+++ b/src/hpc/autoscale/clilib.py
@@ -979,7 +979,9 @@ class CommonCLI(ABC):
         node_names: List[str],
     ) -> None:
         """Reimages the specified nodes."""
-        driver, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
+        if not hostnames and not node_names:
+            error("Please specify at least one hostname with -H/--hostnames or node name with -N/--node-names")
+        _, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
         result = demand_calc.node_mgr.reimage_nodes(nodes)
         print("Reimaging the following nodes:")
         for n in result.nodes or []:
@@ -997,7 +999,9 @@ class CommonCLI(ABC):
         node_names: List[str],
     ) -> None:
         """Restarts the specified nodes."""
-        driver, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
+        if not hostnames and not node_names:
+            error("Please specify at least one hostname with -H/--hostnames or node name with -N/--node-names")
+        _, demand_calc, nodes = self._find_nodes(config, hostnames, node_names)
         result = demand_calc.node_mgr.restart_nodes(nodes)
         print("Restarting the following nodes:")
         for n in result.nodes or []:

--- a/src/hpc/autoscale/node/nodemanager.py
+++ b/src/hpc/autoscale/node/nodemanager.py
@@ -43,7 +43,9 @@ from hpc.autoscale.results import (
     DeallocateResult,
     DeleteResult,
     MatchResult,
+    ReimageResult,
     RemoveResult,
+    RestartResult,
     SatisfiedResult,
     ShutdownResult,
     StartResult,
@@ -1041,6 +1043,18 @@ class NodeManager:
     def shutdown_nodes(self, nodes: List[Node]) -> ShutdownResult:
         return self._nodes_operation(
             nodes, self.__cluster_bindings.shutdown_nodes, ShutdownResult
+        )
+
+    @apitrace
+    def reimage_nodes(self, nodes: List[Node]) -> ReimageResult:
+        return self._nodes_operation(
+            nodes, self.__cluster_bindings.reimage_nodes, ReimageResult
+        )
+
+    @apitrace
+    def restart_nodes(self, nodes: List[Node]) -> RestartResult:
+        return self._nodes_operation(
+            nodes, self.__cluster_bindings.restart_nodes, RestartResult
         )
 
     @apitrace

--- a/src/hpc/autoscale/results.py
+++ b/src/hpc/autoscale/results.py
@@ -304,6 +304,16 @@ class TerminateResult(NodeOperationResult):
 
 
 @hpcwrapclass
+class ReimageResult(NodeOperationResult):
+    ...
+
+
+@hpcwrapclass
+class RestartResult(NodeOperationResult):
+    ...
+
+
+@hpcwrapclass
 class EarlyBailoutResult(Result):
     def __init__(
         self,


### PR DESCRIPTION
Adds base reimage and restart capabilities to CommonCLI for downstream schedulers to inherit. 