### PR TITLE
Ensure shared resources can be used as ints

### DIFF
--- a/example-celery/project.ini
+++ b/example-celery/project.ini
@@ -1,7 +1,7 @@
 [project]
-version = 1.0.10
+version = 1.0.11
 type = application
 name = celery-autoscale-demo
 
 [blobs]
-Files = cyclecloud-scalelib-1.0.10.tar.gz
+Files = cyclecloud-scalelib-1.0.11.tar.gz

--- a/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
+++ b/example-celery/specs/broker/cluster-init/scripts/01.install.packages.sh
@@ -12,8 +12,8 @@ CC_VERSION=$(jetpack config cyclecloud.cookbooks.version)
 wget --no-check-certificate ${cs_hostname}/static/tools/cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 pip install cyclecloud_api-${CC_VERSION}-py2.py3-none-any.whl
 
-jetpack download --project celery-autoscale-demo cyclecloud-scalelib-1.0.10.tar.gz $CYCLECLOUD_SPEC_PATH/files/
-pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-1.0.10.tar.gz
+jetpack download --project celery-autoscale-demo cyclecloud-scalelib-1.0.11.tar.gz $CYCLECLOUD_SPEC_PATH/files/
+pip install $CYCLECLOUD_SPEC_PATH/files/cyclecloud-scalelib-1.0.11.tar.gz
 
 LOGGING_CONF=$(python -c 'import hpc.autoscale, os; print(os.path.abspath(os.path.join(hpc.autoscale.__file__, "..", "logging.conf")))')
 cp $LOGGING_CONF $INSTALLDIR

--- a/example-celery/templates/celery.txt
+++ b/example-celery/templates/celery.txt
@@ -17,7 +17,7 @@ Category = Applications
     Region = $Region
     KeyPairLocation = ~/.ssh/cyclecloud.pem
             
-        [[[cluster-init celery-autoscale-demo:default:1.0.10]]]
+        [[[cluster-init celery-autoscale-demo:default:1.0.11]]]
         Optional = True
 
         [[[configuration]]]
@@ -30,9 +30,9 @@ Category = Applications
     
         [[[configuration]]]
 
-        [[[cluster-init celery-autoscale-demo:broker:1.0.10]]]
+        [[[cluster-init celery-autoscale-demo:broker:1.0.11]]]
         Optional = True
-        [[[cluster-init celery-autoscale-demo:worker:1.0.10]]]
+        [[[cluster-init celery-autoscale-demo:worker:1.0.11]]]
         Optional = True
 
         [[[network-interface eth0]]]
@@ -55,7 +55,7 @@ Category = Applications
         [[[configuration]]]
         celery.broker.privateip = ${broker.instance.privateip}
 
-        [[[cluster-init celery-autoscale-demo:worker:1.0.10]]]
+        [[[cluster-init celery-autoscale-demo:worker:1.0.11]]]
         Optional = True
 
 

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from subprocess import check_call
 from typing import Dict, List, Optional
 
-CYCLECLOUD_SCALELIB_VERSION = "1.0.10"
+CYCLECLOUD_SCALELIB_VERSION = "1.0.11"
 CYCLECLOUD_API_VERSION = "8.9.0"
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.test import test as TestCommand  # noqa: N812
 
 import inspect
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 
 SWAGGER_URL = "https://oss.sonatype.org/content/repositories/releases/io/swagger/swagger-codegen-cli/2.2.1/swagger-codegen-cli-2.2.1.jar"
 SWAGGER_CLI = SWAGGER_URL.split("/")[-1]

--- a/src/hpc/autoscale/node/constraints.py
+++ b/src/hpc/autoscale/node/constraints.py
@@ -1135,11 +1135,21 @@ class SharedConsumableConstraint(SharedConstraint):
         self,
         shared_resources: List[SharedConsumableResource],
         amount: Union[int, float],
+        decrement_once: bool = False,
     ) -> None:
         self.shared_resources = shared_resources
         self.amount = amount
+        # When True, this constraint will decrement the shared resource(s) at
+        # most once for the lifetime of this instance, even when do_decrement is
+        # called multiple times (e.g. once per node a multi-node job spans, or
+        # once per packed iteration). This models a resource that is consumed
+        # a single time for the whole job rather than per-node.
+        self.decrement_once = decrement_once
+        self._decremented = False
 
     def satisfied_by_node(self, node: "Node") -> SatisfiedResult:
+        if self.decrement_once and self._decremented:
+            return SatisfiedResult("success", self, node)
         for shared_resource in self.shared_resources:
             if self.amount > shared_resource.current_value:
                 return SatisfiedResult(
@@ -1159,6 +1169,9 @@ class SharedConsumableConstraint(SharedConstraint):
         return SatisfiedResult("success", self, node)
 
     def do_decrement(self, node: "Node") -> bool:
+        if self.decrement_once and self._decremented:
+            return True
+
         for shared_resource in self.shared_resources:
             if self.amount > shared_resource.current_value:
                 return False
@@ -1166,6 +1179,7 @@ class SharedConsumableConstraint(SharedConstraint):
         for shared_resource in self.shared_resources:
             shared_resource.current_value -= self.amount
 
+        self._decremented = True
         return True
 
     def __str__(self) -> str:

--- a/test/hpc/node/constraints_test.py
+++ b/test/hpc/node/constraints_test.py
@@ -338,3 +338,41 @@ def test_shared_constraint() -> None:
     assert not qcons.do_decrement(node)
     assert global_qres.current_value == 70
     assert queue_qres.current_value == 20
+
+
+def test_shared_constraint_decrement_once() -> None:
+    # decrement_once=True: a single constraint instance consumes the shared
+    # resource at most once, no matter how many times do_decrement is called
+    # (e.g. once per node a multi-node job spans).
+    qres = SharedConsumableResource("qres", "queue", 100, 100)
+    cons = SharedConsumableConstraint([qres], 40, decrement_once=True)
+    node = SchedulerNode("tux", {})
+
+    assert cons.satisfied_by_node(node)
+    assert cons.do_decrement(node)
+    assert qres.current_value == 60
+
+    # subsequent calls on the same instance are no-ops and the value stays put
+    assert cons.satisfied_by_node(node)
+    assert cons.do_decrement(node)
+    assert qres.current_value == 60
+
+    assert cons.do_decrement(node)
+    assert qres.current_value == 60
+
+    # a fresh instance (e.g. a different job) decrements the shared value again
+    cons2 = SharedConsumableConstraint([qres], 40, decrement_once=True)
+    assert cons2.satisfied_by_node(node)
+    assert cons2.do_decrement(node)
+    assert qres.current_value == 20
+
+    # and it too only decrements once
+    assert cons2.do_decrement(node)
+    assert qres.current_value == 20
+
+    # default behavior (decrement_once=False) is unchanged: decrements every call
+    counting = SharedConsumableResource("qres", "queue", 100, 100)
+    cons3 = SharedConsumableConstraint([counting], 10)
+    assert cons3.do_decrement(node)
+    assert cons3.do_decrement(node)
+    assert counting.current_value == 80


### PR DESCRIPTION
Fixes issues in pbs where ints were divided by the number of nodes in a job and small floating point errors would accumulate under certain situations.